### PR TITLE
tests: add --timed logging and benchmark mode to run_tests.py

### DIFF
--- a/tests/test_master_e2e.py
+++ b/tests/test_master_e2e.py
@@ -17,6 +17,9 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 
+@pytest.mark.e2e
+@pytest.mark.integration
+@pytest.mark.slow
 class TestMasterE2E:
     """Complete E2E test of all claimed features."""
 
@@ -654,8 +657,8 @@ result = process_data(None)
         else:
             print("⚠️  MONASTERY 0.8.0 BETA: SIGNIFICANT GAPS DETECTED")
 
-        # Don't fail the test - this is a report
-        return validations
+        # Don't fail the test - this is a report; avoid returning non-None to silence pytest warning
+        # Intentionally no return value
 
 
 def run_manual_verification():


### PR DESCRIPTION
Adds recorded timing for test runs and a benchmark mode.\n\n- New flag: --timed writes an entry to logs/benchmarks/test_timings.jsonl (UTC ISO timestamp, mode, duration, exit_code)\n- New mode: --benchmark runs just the benchmark test suite (pattern intelligence benchmarks)\n- Timing supported for specific tests via run_tests.py <file> --timed as well\n- Uses timezone-aware timestamps to avoid deprecation warnings\n\nThis enables tracking performance evolution over time and fulfills the CLI promise in docs.